### PR TITLE
Added ability to set server-specific prefixes

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -1,6 +1,6 @@
 const { Client, Collection } = require('discord.js');
 const { prefix: DEFAULT_PREFIX, DEFAULT_COOLDOWN } = require('./config.json');
-const { getServerPrefixes } = require('./mongo/settings.js');
+const { getGuildPrefixes } = require('./mongo/settings.js');
 const fs = require('fs');
 require('dotenv').config();
 
@@ -26,7 +26,7 @@ client.once('ready', async () => {
   console.log(`${client.user.username} is ready!`);
   client.user.setActivity('Legends of Idleon');
   try {
-    const prefixes = await getServerPrefixes();
+    const prefixes = await getGuildPrefixes();
     prefixes.forEach(({ guildID, prefix: guildPrefix }) => {
       const guild = client.guildSettings.get(guildID) || {};
       client.guildSettings.set(guildID, { ...guild, prefix: guildPrefix });

--- a/bot.js
+++ b/bot.js
@@ -27,6 +27,7 @@ client.once('ready', async () => {
   client.user.setActivity('Legends of Idleon');
   try {
     const prefixes = await getGuildPrefixes();
+    console.log(prefixes);
     prefixes.forEach(({ guildID, prefix: guildPrefix }) => {
       const guild = client.guildSettings.get(guildID) || {};
       client.guildSettings.set(guildID, { ...guild, prefix: guildPrefix });
@@ -37,11 +38,11 @@ client.once('ready', async () => {
 });
 
 client.on('message', (message) => {
-  // Ensures each server uses its own prefix (if defined), uses default prefix in dms
-  let prefix;
-  if (message.channel.type !== 'dm') {
-    prefix = client.guildSettings.get(message.guild.id).prefix || DEFAULT_PREFIX;
-  }
+  // Ensures each server uses its own settings (if defined), uses default settings in dms
+  const settings = (message.channel.type !== 'dm') ?
+    client.guildSettings.get(message.guild.id) :
+    undefined;
+  const prefix = settings ? settings.prefix : DEFAULT_PREFIX;
 
   if (shouldIgnore(message, prefix)) return;
 
@@ -60,6 +61,7 @@ client.on('message', (message) => {
     cooldowns.set(command.name, new Collection());
   }
 
+  // Cooldown implementation
   const now = Date.now();
   const timestamps = cooldowns.get(command.name);
   const cooldownAmount = (command.cooldown || DEFAULT_COOLDOWN) * 1000;
@@ -81,6 +83,7 @@ client.on('message', (message) => {
     setTimeout(() => timestamps.delete(message.author.id), cooldownAmount);
   }
 
+  // Handles command uses with no arguments (when necessary)
   if (command.args && !args.length) {
     let reply = `You didn't provide any arguments, ${message.author}`;
 

--- a/commands/prefix.js
+++ b/commands/prefix.js
@@ -5,18 +5,24 @@ module.exports = {
   description: 'Changes prefix for current server',
   args: true,
   usage: '<new prefix>',
+  whitelist: ['90598254688874496', '191085842469486592'],
   async execute(message, args) {
-    const newPrefix = args[0];
-    if (args[0] && args[0].length === 0) return message.channel.send('Prefix must be at least 1 character!');
-    try {
-      const guildID = message.guild.id;
-      const guildSettings = message.client.guildSettings.get(guildID) || {};
-      updateGuildPrefix(guildID, newPrefix);
-      message.client.guildSettings.set(guildID, { ...guildSettings, prefix: newPrefix });
-      message.channel.send(`Prefix is now sent to ${newPrefix}`);
-    } catch (err) {
-      console.log(err);
-    }
+    if (this.whitelist.includes(message.author.id)) {
+      if (args[0] && args[0].length === 0) return message.channel.send('Prefix must be at least 1 character!');
 
+      try {
+        const newPrefix = args[0];
+        const guildID = message.guild.id;
+        const guildSettings = message.client.guildSettings.get(guildID) || {};
+        updateGuildPrefix(guildID, newPrefix);
+        message.client.guildSettings.set(guildID, { ...guildSettings, prefix: newPrefix });
+        message.channel.send(`Prefix is now sent to ${newPrefix}`);
+      } catch (err) {
+        console.log(err);
+      }
+
+    } else {
+      message.channel.send('You cannot use this command!');
+    }
   },
 };

--- a/commands/prefix.js
+++ b/commands/prefix.js
@@ -1,0 +1,21 @@
+const { updateServerPrefix } = require('../mongo/settings.js');
+
+module.exports = {
+  name: 'prefix',
+  description: 'Changes prefix for current server',
+  args: true,
+  async execute(message, args) {
+    const newPrefix = args[0];
+    if (args[0] && args[0].length === 0) return message.channel.send('Prefix must be at least 1 character!');
+    try {
+      const guildID = message.guild.id;
+      const guildSettings = message.client.guildSettings.get(guildID) || {};
+      updateServerPrefix(guildID, newPrefix);
+      message.client.guildSettings.set(guildID, { ...guildSettings, prefix: newPrefix });
+      message.channel.send(`Prefix is now sent to ${newPrefix}`);
+    } catch (err) {
+      console.log(err);
+    }
+
+  },
+};

--- a/commands/prefix.js
+++ b/commands/prefix.js
@@ -4,6 +4,7 @@ module.exports = {
   name: 'prefix',
   description: 'Changes prefix for current server',
   args: true,
+  usage: '<new prefix>',
   async execute(message, args) {
     const newPrefix = args[0];
     if (args[0] && args[0].length === 0) return message.channel.send('Prefix must be at least 1 character!');

--- a/commands/prefix.js
+++ b/commands/prefix.js
@@ -1,4 +1,4 @@
-const { updateServerPrefix } = require('../mongo/settings.js');
+const { updateGuildPrefix } = require('../mongo/settings.js');
 
 module.exports = {
   name: 'prefix',
@@ -11,7 +11,7 @@ module.exports = {
     try {
       const guildID = message.guild.id;
       const guildSettings = message.client.guildSettings.get(guildID) || {};
-      updateServerPrefix(guildID, newPrefix);
+      updateGuildPrefix(guildID, newPrefix);
       message.client.guildSettings.set(guildID, { ...guildSettings, prefix: newPrefix });
       message.channel.send(`Prefix is now sent to ${newPrefix}`);
     } catch (err) {

--- a/mongo/connection.js
+++ b/mongo/connection.js
@@ -3,6 +3,7 @@ require('dotenv').config();
 
 const MongoConnection = {
   url: `mongodb+srv://${process.env.MONGO_USER}:${process.env.MONGO_PASS}@scripticus.jwgax.mongodb.net/Scripticus?retryWrites=true&w=majority`,
+  // url: `mongodb+srv://${process.env.MONGO_USER}:${process.env.MONGO_PASS}@scripticus.63urb.mongodb.net/scripticus?retryWrites=true&w=majority`,
   options:  {
     useUnifiedTopology: true,
     useNewUrlParser: true

--- a/mongo/connection.js
+++ b/mongo/connection.js
@@ -2,8 +2,12 @@ const { MongoClient } = require('mongodb');
 require('dotenv').config();
 
 const MongoConnection = {
+  url: `mongodb+srv://${process.env.MONGO_USER}:${process.env.MONGO_PASS}@scripticus.jwgax.mongodb.net/Scripticus?retryWrites=true&w=majority`,
+  options:  {
+    useUnifiedTopology: true,
+    useNewUrlParser: true
+  },
   connectToDatabase() {
-    if (this.db) return Promise.resolve(this.db);
     return MongoClient.connect(this.url, this.options)
       .then(connection => {
         this.db = connection.db();
@@ -16,11 +20,5 @@ const MongoConnection = {
   }
 };
 
-MongoConnection.db = null;
-MongoConnection.url = `mongodb+srv://${process.env.MONGO_USER}:${process.env.MONGO_PASS}@scripticus.jwgax.mongodb.net/Scripticus?retryWrites=true&w=majority`;
-MongoConnection.options = {
-  useUnifiedTopology: true,
-  useNewUrlParser: true
-};
 MongoConnection.connectToDatabase();
 module.exports = { MongoConnection };

--- a/mongo/settings.js
+++ b/mongo/settings.js
@@ -1,0 +1,25 @@
+const { MongoConnection } = require('./connection.js');
+
+module.exports = {
+  async updateServerPrefix(guildID, newPrefix) {
+    const filter = { guildID: String(guildID) };
+    const updateOp = { $set: { prefix: newPrefix } };
+    const options = { upsert: true };
+    await MongoConnection.db
+      .collection('servers')
+      .updateOne(filter, updateOp, options);
+  },
+  async getServerPrefixes() {
+    const query = {};
+    const options = { projection: { guildID: 1, prefix: 1 } };
+    try {
+      const serverPrefixes = await MongoConnection.db
+        .collection('servers')
+        .find(query, options)
+        .toArray();
+      return serverPrefixes;
+    } catch (err) {
+      console.error(err);
+    }
+  }
+};

--- a/mongo/settings.js
+++ b/mongo/settings.js
@@ -1,25 +1,28 @@
 const { MongoConnection } = require('./connection.js');
 
 module.exports = {
-  async updateServerPrefix(guildID, newPrefix) {
+  async updateGuildPrefix(guildID, newPrefix) {
     const filter = { guildID: String(guildID) };
     const updateOp = { $set: { prefix: newPrefix } };
     const options = { upsert: true };
     await MongoConnection.db
-      .collection('servers')
+      .collection('guilds')
       .updateOne(filter, updateOp, options);
   },
-  async getServerPrefixes() {
+  async getGuildPrefixes() {
     const query = {};
     const options = { projection: { guildID: 1, prefix: 1 } };
     try {
-      const serverPrefixes = await MongoConnection.db
-        .collection('servers')
+      const guildPrefixes = await MongoConnection.db
+        .collection('guilds')
         .find(query, options)
         .toArray();
-      return serverPrefixes;
+      return guildPrefixes;
     } catch (err) {
       console.error(err);
     }
+  },
+  async updateGuildCooldown(guildID) {
+    console.log(guildID);
   }
 };


### PR DESCRIPTION
- Added new mongo/settings.js file containing necessary functions to get and update server prefixes
- bot.js will load in current server prefixes from db on startup (located in 'ready' event listener callback)
- After initial load of prefixes, any additional prefix changes while bot is online are inserted to DB and changed 'locally' on the bot
- shouldIgnore function now takes a prefix as argument
- prefix from config.json is now the 'default' prefix

Should be a start to #35 , there might be some growing pains when implementing additional settings (like which channels it should be allowed in, which commands are allowed to which users, etc.)